### PR TITLE
feat: add register and login routes with bcrypt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2031,6 +2031,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -2699,9 +2713,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -3563,6 +3577,26 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -4752,6 +4786,7 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^11.2.0",
+        "bcrypt": "^6.0.0",
         "dotenv": "^17.3.1",
         "fastify": "^5.8.2",
         "pg": "^8.20.0",

--- a/server/package.json
+++ b/server/package.json
@@ -5,17 +5,18 @@
   "license": "MIT",
   "author": "Vlad",
   "type": "module",
-  "main": "server.js", 
+  "main": "server.js",
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "migrate": "node src/db/scripts/migrate.js",    
+    "migrate": "node src/db/scripts/migrate.js",
     "db:ping": "node --env-file=.env.development tests/db/pool.test.js",
     "db:create_data": "node --env-file=.env.development tests/db/db.create_user.test.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "bcrypt": "^6.0.0",
     "dotenv": "^17.3.1",
     "fastify": "^5.8.2",
     "pg": "^8.20.0",

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ import cors from "@fastify/cors"
 
 import { env } from './src/config/env.js'
 import homeRoutes from './src/apps/home/entry-points/home.routes.js'
+import authRoutes from "./src/apps/auth/entry-points/auth.routes.js";
 import eventHandler from './src/libraries/events/events.controller.js'
 
 import query from './src/db/pool.js';
@@ -52,9 +53,12 @@ fastify.register(eventHandler, {prefix: '/stream'});
 // home
 fastify.register(homeRoutes, {prefix: '/home'});
 
-try {
+// auth 
+fastify.register(authRoutes, {prefix: '/auth'});
 
+try {
     await fastify.listen(port);
+    
 } catch (err) {
     fastify.log.fatal(err);
     process.exit(1);

--- a/server/src/apps/auth/data-access/auth.repository.js
+++ b/server/src/apps/auth/data-access/auth.repository.js
@@ -1,0 +1,12 @@
+import query from "../../../db/pool";
+
+export class DataAccessModule {
+    static async registerUser (email, password, username) {
+        const { rows } = await query(
+            ``,
+            [email, password, username]
+        )
+
+        return rows;
+    } 
+}

--- a/server/src/apps/auth/data-access/auth.repository.js
+++ b/server/src/apps/auth/data-access/auth.repository.js
@@ -32,4 +32,15 @@ export class DataAccessModule {
 
         return rows;
     }
+
+    static async logIn (email) {
+        const { rows } = await query(
+            `SELECT id, password_hash FROM users
+            WHERE email = $1 AND is_verified = TRUE;
+            `, 
+            [email]
+        );
+
+        return rows;
+    }
 }

--- a/server/src/apps/auth/data-access/auth.repository.js
+++ b/server/src/apps/auth/data-access/auth.repository.js
@@ -1,4 +1,4 @@
-import query from "../../../db/pool";
+import query from "../../../db/pool.js";
 export class DataAccessModule {
     static async registerUser(email, password, username, confirmToken, expires) {
         const { rows } = await query(

--- a/server/src/apps/auth/data-access/auth.repository.js
+++ b/server/src/apps/auth/data-access/auth.repository.js
@@ -1,12 +1,33 @@
 import query from "../../../db/pool.js";
 export class DataAccessModule {
-    static async registerUser(email, password, username, confirmToken, expires) {
+    static async registerUser(
+        email,
+        password,
+        username,
+        confirmToken,
+        expires,
+    ) {
         const { rows } = await query(
             `INSERT INTO users
             (email, password_hash, username, verification_token, token_expires_at)
             VALUES ($1, $2, $3, $4, $5)
             RETURNING verification_token`,
             [email, password, username, confirmToken, expires],
+        );
+
+        return rows;
+    }
+
+    static async verify(token) {
+        const { rows } = await query(
+            `UPDATE users
+            SET is_verified = TRUE,
+                verification_token = NULL,
+                token_expires_at = NULL
+            WHERE verification_token = $1
+                AND token_expires_at > NOW()
+            RETURNING id`,
+            [token],
         );
 
         return rows;

--- a/server/src/apps/auth/data-access/auth.repository.js
+++ b/server/src/apps/auth/data-access/auth.repository.js
@@ -1,12 +1,14 @@
 import query from "../../../db/pool";
-
 export class DataAccessModule {
-    static async registerUser (email, password, username) {
+    static async registerUser(email, password, username, confirmToken, expires) {
         const { rows } = await query(
-            ``,
-            [email, password, username]
-        )
+            `INSERT INTO users
+            (email, password_hash, username, verification_token, token_expires_at)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING verification_token`,
+            [email, password, username, confirmToken, expires],
+        );
 
         return rows;
-    } 
+    }
 }

--- a/server/src/apps/auth/domain/auth.schema.js
+++ b/server/src/apps/auth/domain/auth.schema.js
@@ -1,12 +1,17 @@
 import { z } from "zod";
 
-const schema = z.object({
+const registerSchema = z.object({
         email: z.string().email({ message: "email address is not valid" }),
         password: z.string().min(8, { message: "password must be at least 8 characters long" }),
-        username: z.string().min(3).max(20).optional(),
+        username: z.string().min(3).max(20),
 });
 
-export default function inputValidation(data) {
+const logInSchema = z.object({
+        email: z.string().email({ message: "email address is not valid" }),
+        password: z.string().min(8, { message: "password must be at least 8 characters long" }),
+});
+
+function inputValidation(data, schema) {
 
     const result = schema.safeParse(data);
 
@@ -24,3 +29,6 @@ export default function inputValidation(data) {
         data: result.data 
     }  
 }
+
+export const validateRegister = data => inputValidation(data, registerSchema);
+export const validateLogIn = data => inputValidation(data, logInSchema);

--- a/server/src/apps/auth/domain/auth.schema.js
+++ b/server/src/apps/auth/domain/auth.schema.js
@@ -11,7 +11,7 @@ export default function inputValidation(data) {
     const result = schema.safeParse(data);
 
     if (!result.success) {
-        const errorsMessages = resul.error.errors.map(err => err.message);
+        const errorsMessages = result.error.errors.map(err => err.message);
 
         return {
             isValid: false,

--- a/server/src/apps/auth/domain/auth.schema.js
+++ b/server/src/apps/auth/domain/auth.schema.js
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+const schema = z.object({
+        email: z.string().email({ message: "email address is not valid" }),
+        password: z.string().min(8, { message: "password must be at least 8 characters long" }),
+        username: z.string().min(3).max(20).optional(),
+});
+
+export default function inputValidation(data) {
+
+    const result = schema.safeParse(data);
+
+    if (!result.success) {
+        const errorsMessages = resul.error.errors.map(err => err.message);
+
+        return {
+            isValid: false,
+            errors: errorsMessages
+        }
+    }
+
+    return {
+        isValid: true,
+        data: result.data 
+    }  
+}

--- a/server/src/apps/auth/domain/auth.service.js
+++ b/server/src/apps/auth/domain/auth.service.js
@@ -5,6 +5,7 @@ import { DataAccessModule } from "../data-access/auth.repository.js";
 
 export async function register(data) {
     const { email, password, username } = data;
+
     const hashingRounds = 12;
 
     const encriptedPassword = await bcrypt.hash(password, hashingRounds);

--- a/server/src/apps/auth/domain/auth.service.js
+++ b/server/src/apps/auth/domain/auth.service.js
@@ -8,37 +8,58 @@ export async function register(data) {
 
     const hashingRounds = 12;
 
-    const encriptedPassword = await bcrypt.hash(password, hashingRounds);
+    const encryptedPassword = await bcrypt.hash(password, hashingRounds);
 
     //email verification data
-    const confirmToken = crypto.randomBytes(32).toString('hex');
+    const confirmToken = crypto.randomBytes(32).toString("hex");
 
     const expires = new Date();
-    const hoursToExpire = 24 
+    const hoursToExpire = 24;
     expires.setHours(expires.getHours() + hoursToExpire);
-
-
 
     const rows = await DataAccessModule.registerUser(
         email,
-        encriptedPassword,
+        encryptedPassword,
         username,
         confirmToken,
-        expires
+        expires,
     );
 
     return rows;
 }
 
-export async function verify (token) {
+export async function verify(token) {
     const rows = await DataAccessModule.verify(token);
 
     if (rows.length === 0) {
         const error = new Error("Invalid token");
         error.statusCode = 400;
-        throw error
+        throw error;
     }
 
     return true;
 }
 
+export async function logIn(data) {
+    const { email, password } = data;
+
+    const assertValid = inCase => {
+        if (inCase) {
+            const error = new Error("Invalid email or password");
+            error.statusCode = 401;
+            throw error;
+        }
+    };
+
+    const rows = await DataAccessModule.logIn(email);
+
+    assertValid(rows.length === 0);
+
+    const { id, password_hash } = rows[0];
+
+    const isValid = await bcrypt.compare(password, password_hash);
+
+    assertValid(!isValid);
+    
+    return { id, message: "Login successful" };
+}

--- a/server/src/apps/auth/domain/auth.service.js
+++ b/server/src/apps/auth/domain/auth.service.js
@@ -1,0 +1,18 @@
+import bcrypt from "bcrypt";
+
+import { DataAccessModule } from "../data-access/auth.repository.js";
+
+export async function register(data) {
+    const { email, password, username } = data;
+    const hashingRounds = 12;
+
+    const encriptedPassword = await bcrypt.hash(password, hashingRounds);
+
+    const rows = await DataAccessModule.registerUser(
+        email,
+        encriptedPassword,
+        username,
+    );
+
+    return rows;
+}

--- a/server/src/apps/auth/domain/auth.service.js
+++ b/server/src/apps/auth/domain/auth.service.js
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import bcrypt from "bcrypt";
 
 import { DataAccessModule } from "../data-access/auth.repository.js";
@@ -8,10 +9,21 @@ export async function register(data) {
 
     const encriptedPassword = await bcrypt.hash(password, hashingRounds);
 
+    //email verification data
+    const confirmToken = crypto.randomBytes(32).toString('hex');
+
+    const expires = new Date();
+    const hoursToExpire = 24 
+    expires.setHours(expires.getHours() + hoursToExpire);
+
+
+
     const rows = await DataAccessModule.registerUser(
         email,
         encriptedPassword,
         username,
+        confirmToken,
+        expires
     );
 
     return rows;

--- a/server/src/apps/auth/domain/auth.service.js
+++ b/server/src/apps/auth/domain/auth.service.js
@@ -29,3 +29,16 @@ export async function register(data) {
 
     return rows;
 }
+
+export async function verify (token) {
+    const rows = await DataAccessModule.verify(token);
+
+    if (rows.length === 0) {
+        const error = new Error("Invalid token");
+        error.statusCode = 400;
+        throw error
+    }
+
+    return true;
+}
+

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -21,6 +21,12 @@ export const register = async (req, reply) => {
 
         return reply.status(201).send(IsRegisteredHash); //email verification
     } catch (error) {
+        if (error.code === "23505") {
+            return reply
+                .status(409)
+                .send({ message: "user with this email already exists" });
+        }
+
         console.error("[REGISTER ERROR]", error);
         return reply.status(500).send({ error: "Internal Server Error" });
     }

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -1,0 +1,22 @@
+import * as authService from "../domain/auth.service.js";
+
+export const register = async (req, reply) => {
+    try {
+        const data = req.body;
+        // const typeSefaData = zodSchema(data);
+        const IsRegisteredHash = await authService.register(data);
+        
+        reply
+            .status(201)
+            .send(IsRegisteredHash); //email verification
+
+    } catch (error) {
+        console.error("[REGISTER ERROR]", error);
+        reply.status(500).send({ error: "Internal Server Error" });
+    }
+};
+
+// export const logIn = async (req, reply) => {
+//     reply.status(200);
+
+// };

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -1,12 +1,12 @@
 import * as authService from "../domain/auth.service.js";
 
-import inputValidation from "../domain/auth.schema.js";
+import { validateLogIn, validateRegister } from "../domain/auth.schema.js";
 
 export const register = async (req, reply) => {
     try {
         //data validation handling
         const data = req.body;
-        const validation = inputValidation(data);
+        const validation = validateRegister(data);
 
         if (!validation.isValid) {
             return reply.status(400).send({
@@ -52,7 +52,7 @@ export const verify = async (req, reply) => {
 
 export const logIn = async (req, reply) => {
     const data = req.body;
-    const validation = inputValidation(data);
+    const validation = validateLogIn(data);
 
     if (!validation.isValid) {
         return reply.status(400).send({

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -9,8 +9,8 @@ export const register = async (req, reply) => {
         const validation = inputValidation(data);
 
         if (!validation.isValid) {
-            return reply.status(400).send({ 
-                error: "Validation failed", 
+            return reply.status(400).send({
+                error: "Validation failed",
                 details: validation.errors,
             });
         }
@@ -19,17 +19,30 @@ export const register = async (req, reply) => {
         //registering user
         const IsRegisteredHash = await authService.register(validData);
 
-        reply
-            .status(201)
-            .send(IsRegisteredHash); //email verification
-
+        return reply.status(201).send(IsRegisteredHash); //email verification
     } catch (error) {
-        
         console.error("[REGISTER ERROR]", error);
-        reply.status(500).send({ error: "Internal Server Error" });
+        return reply.status(500).send({ error: "Internal Server Error" });
     }
 };
 
+export const verify = async (req, reply) => {
+    const { token } = req.query;
+
+    try {
+        await authService.verify(token);
+        return reply
+            .status(201)
+            .send({ message: "User verified successfully" });
+    } catch (error) {
+        if (error.statusCode === 400) {
+            return reply.status(400).send({ error: error.message });
+        }
+
+        console.error("[VERIFY ERROR]", error);
+        return reply.status(500).send({ error: "Internal Server Error" });
+    }
+};
 // export const logIn = async (req, reply) => {
 //     reply.status(200);
 

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -1,16 +1,30 @@
 import * as authService from "../domain/auth.service.js";
 
+import inputValidation from "../domain/auth.schema.js";
+
 export const register = async (req, reply) => {
     try {
+        //data validation handling
         const data = req.body;
-        // const typeSefaData = zodSchema(data);
-        const IsRegisteredHash = await authService.register(data);
-        
+        const validation = inputValidation(data);
+
+        if (!validation.isValid) {
+            return reply.status(400).send({ 
+                error: "Validation failed", 
+                details: validation.errors,
+            });
+        }
+        const validData = validation.data;
+
+        //registering user
+        const IsRegisteredHash = await authService.register(validData);
+
         reply
             .status(201)
             .send(IsRegisteredHash); //email verification
 
     } catch (error) {
+        
         console.error("[REGISTER ERROR]", error);
         reply.status(500).send({ error: "Internal Server Error" });
     }

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -43,7 +43,31 @@ export const verify = async (req, reply) => {
         return reply.status(500).send({ error: "Internal Server Error" });
     }
 };
-// export const logIn = async (req, reply) => {
-//     reply.status(200);
 
-// };
+export const logIn = async (req, reply) => {
+    const data = req.body;
+    const validation = inputValidation(data);
+
+    if (!validation.isValid) {
+        return reply.status(400).send({
+            error: "Validation failed",
+            details: validation.errors,
+        });
+    }
+    const validData = validation.data;
+
+    try {
+        const { id, message } = await authService.logIn(validData);
+
+        return reply.status(200).send({ id, message });
+    } catch (error) {
+        if (error.statusCode === 401) {
+            return reply
+                .status(error.statusCode)
+                .send({ error: error.message });
+        }
+
+        console.error("[LOGIN ERROR]", error);
+        return reply.status(500).send({ error: "Internal Server Error" });
+    }
+};

--- a/server/src/apps/auth/entry-points/auth.routes.js
+++ b/server/src/apps/auth/entry-points/auth.routes.js
@@ -3,7 +3,7 @@ import * as authController from "./auth.controller.js";
 export default function authRoutes (fastify, components, done) {
     fastify.post("/register", authController.register);
     
-    fastify.post("/login", authController.logIn);
+    // fastify.post("/login", authController.logIn);
 
     done();
 }

--- a/server/src/apps/auth/entry-points/auth.routes.js
+++ b/server/src/apps/auth/entry-points/auth.routes.js
@@ -2,6 +2,8 @@ import * as authController from "./auth.controller.js";
 
 export default function authRoutes (fastify, components, done) {
     fastify.post("/register", authController.register);
+
+    fastify.get("/verify", authController.verify);
     
     // fastify.post("/login", authController.logIn);
 

--- a/server/src/apps/auth/entry-points/auth.routes.js
+++ b/server/src/apps/auth/entry-points/auth.routes.js
@@ -1,0 +1,9 @@
+import * as authController from "./auth.controller.js";
+
+export default function authRoutes (fastify, components, done) {
+    fastify.post("/register", authController.register);
+    
+    fastify.post("/login", authController.logIn);
+
+    done();
+}

--- a/server/src/apps/auth/entry-points/auth.routes.js
+++ b/server/src/apps/auth/entry-points/auth.routes.js
@@ -5,7 +5,7 @@ export default function authRoutes (fastify, components, done) {
 
     fastify.get("/verify", authController.verify);
     
-    // fastify.post("/login", authController.logIn);
+    fastify.post("/login", authController.logIn);
 
     done();
 }

--- a/server/src/db/migrations/001_create_users.sql
+++ b/server/src/db/migrations/001_create_users.sql
@@ -1,18 +1,15 @@
-CREATE TABLE IF NOT EXISTS users (
-    id UUID 
-        DEFAULT gen_random_uuid(),
-    username VARCHAR(255) NOT NULL,
-    password_hash VARCHAR(400) NOT NULL,
-    email VARCHAR(60) UNIQUE NOT NULL,
-    profile_photo VARCHAR(255),
-    profile_description TEXT,
-    role VARCHAR(20) NOT NULL 
-        DEFAULT 'student'
-        CHECK (role IN ('student', 'teacher', 'admin')),
-    created_at          TIMESTAMPTZ  NOT NULL 
-        DEFAULT NOW(),
-    updated_at          TIMESTAMPTZ  NOT NULL 
-        DEFAULT NOW(),
-
-    PRIMARY KEY (id)
-)
+CREATE TABLE
+    IF NOT EXISTS users (
+        id UUID DEFAULT gen_random_uuid (),
+        username VARCHAR(255) NOT NULL,
+        password_hash VARCHAR(400) NOT NULL,
+        email VARCHAR(60) UNIQUE NOT NULL,
+        profile_photo VARCHAR(255),
+        profile_description TEXT,
+        role VARCHAR(20) NOT NULL 
+            DEFAULT 'student' CHECK (role IN ('student', 'teacher', 'admin')),
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW (),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW (),
+        
+        PRIMARY KEY (id)
+    )

--- a/server/src/db/migrations/002_create_quizzes.sql
+++ b/server/src/db/migrations/002_create_quizzes.sql
@@ -1,17 +1,16 @@
-CREATE TABLE IF NOT EXISTS quizzes (
-    id UUID  
-        DEFAULT gen_random_uuid(), 
-    creator_id UUID NOT NULL, 
-    title VARCHAR(255) NOT NULL, 
-    bg_image TEXT, 
-    description TEXT, 
-    visibility  VARCHAR(9)  NOT NULL DEFAULT 'private'
-        CHECK (visibility IN ('public', 'private', 'unlisted')),
-    points INT 
-        DEFAULT NULL,
-    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-
-    PRIMARY KEY (id),
-    FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE CASCADE
+CREATE TABLE
+    IF NOT EXISTS quizzes (
+        id UUID DEFAULT gen_random_uuid (),
+        creator_id UUID NOT NULL,
+        title VARCHAR(255) NOT NULL,
+        bg_image TEXT,
+        description TEXT,
+        visibility VARCHAR(9) NOT NULL 
+            DEFAULT 'private' CHECK (visibility IN ('public', 'private', 'unlisted')),
+        points INT DEFAULT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW (),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW (),
+        
+        PRIMARY KEY (id),
+        FOREIGN KEY (creator_id) REFERENCES users (id) ON DELETE CASCADE
     )

--- a/server/src/db/migrations/003_create_questions.sql
+++ b/server/src/db/migrations/003_create_questions.sql
@@ -1,13 +1,13 @@
-CREATE TABLE IF NOT EXISTS questions (
-    id UUID 
-        DEFAULT gen_random_uuid(),
-    quiz_id UUID NOT NULL,
-    question VARCHAR(1000) NOT NULL,
-    type VARCHAR(20) NOT NULL 
-        CHECK (type IN ('single', 'multiple', 'text', 'image')),
-    points INT,
-    position INTEGER NOT NULL DEFAULT 0,
-
-    PRIMARY KEY (id),
-    FOREIGN KEY (quiz_id) REFERENCES quizzes(id) ON DELETE CASCADE
-)
+CREATE TABLE
+    IF NOT EXISTS questions (
+        id UUID DEFAULT gen_random_uuid (),
+        quiz_id UUID NOT NULL,
+        question VARCHAR(1000) NOT NULL,
+        type VARCHAR(20) NOT NULL 
+            CHECK (type IN ('single', 'multiple', 'text', 'image')),
+        points INT,
+        position INTEGER NOT NULL DEFAULT 0,
+        
+        PRIMARY KEY (id),
+        FOREIGN KEY (quiz_id) REFERENCES quizzes (id) ON DELETE CASCADE
+    )

--- a/server/src/db/migrations/004_create_options.sql
+++ b/server/src/db/migrations/004_create_options.sql
@@ -1,13 +1,11 @@
-CREATE TABLE IF NOT EXISTS options (
-    id UUID 
-        DEFAULT gen_random_uuid(),
-    question_id UUID NOT NULL,
-    body VARCHAR(500) NOT NULL,
-    is_correct BOOLEAN
-        DEFAULT false,
-    position INT NOT NULL 
-        DEFAULT 0,
-
-    PRIMARY KEY (id),
-    FOREIGN KEY (question_id) REFERENCES questions(id) ON DELETE CASCADE
-)
+CREATE TABLE
+    IF NOT EXISTS options (
+        id UUID DEFAULT gen_random_uuid (),
+        question_id UUID NOT NULL,
+        body VARCHAR(500) NOT NULL,
+        is_correct BOOLEAN DEFAULT false,
+        position INT NOT NULL DEFAULT 0,
+        
+        PRIMARY KEY (id),
+        FOREIGN KEY (question_id) REFERENCES questions (id) ON DELETE CASCADE
+    )

--- a/server/src/db/migrations/005_edit_users.sql
+++ b/server/src/db/migrations/005_edit_users.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users
+    ADD COLUMN is_verified BOOLEAN DEFAULT false,
+    ADD COLUMN verification_token VARCHAR(255),
+    ADD COLUMN token_expires_at TIMESTAMPTZ;


### PR DESCRIPTION
### WHAT CHANGED · CLOSES 

Implements both auth routes. bcrypt cost factor set to 12 — high enough to be slow for attackers, fast enough for users. Login returns a generic error message regardless of whether email or password was wrong — prevents user enumeration attacks.

### HOW TO TEST

- [x] POST /auth/register with valid body — 201 response
- [ ] POST /auth/register again with same email — 409
- [x] POST /auth/login with correct creds — 200
- [x] POST /auth/login with wrong password — 401 (same message as wrong email)

### FILES CHANGED

```
+src/modules/auth/auth.controller.js
+src/modules/auth/auth.service.js
+src/modules/auth/auth.repository.js
~src/app.js (register auth routes)