### PR TITLE
feat:  JWT via HTTP-Only cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -949,6 +949,26 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@fastify/cookie": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.0.2.tgz",
+      "integrity": "sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.0",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
     "node_modules/@fastify/cors": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
@@ -1019,6 +1039,29 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@fastify/jwt": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/jwt/-/jwt-10.1.0.tgz",
+      "integrity": "sha512-U1y8ZbxoH1Pjon3euzPJmbCkuYBM+hrQlFWLQWvKmJGCNT6mVsAolnVJdEWfXeQOKpgmuRVCIsPll5RLZxj10A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.2.0",
+        "@lukeed/ms": "^2.0.2",
+        "fast-jwt": "^6.2.0",
+        "fastify-plugin": "^5.0.1",
+        "steed": "^1.1.3"
+      }
     },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
@@ -1168,6 +1211,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -1982,6 +2034,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -2044,6 +2108,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -2330,6 +2400,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2689,6 +2768,22 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/fast-jwt": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-6.2.4.tgz",
+      "integrity": "sha512-IoQa53wI6TbARU2yelb0L44ggFQnP2qVcwswCSYHbCAWuwpr70icDb3QjG0v01I8Tt01rVGDkN/rRvpk0lKFTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "asn1.js": "^5.4.1",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "mnemonist": "^0.40.0",
+        "safe-regex2": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2727,6 +2822,18 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastfall": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fastfall/-/fastfall-1.5.1.tgz",
+      "integrity": "sha512-KH6p+Z8AKPXnmA7+Iz2Lh8ARCMr+8WNPVludm1LGkZoD2MjY6LVnRMtTKhkdzI+jr0RzQWXKzKyBJm1zoHEL4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "reusify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fastify": {
       "version": "5.8.5",
@@ -2789,6 +2896,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/fastparallel": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/fastparallel/-/fastparallel-2.4.1.tgz",
+      "integrity": "sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4",
+        "xtend": "^4.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -2796,6 +2913,16 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fastseries": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/fastseries/-/fastseries-1.7.2.tgz",
+      "integrity": "sha512-dTPFrPGS8SNSzAt7u/CbMKCJ3s01N04s4JFbORHcmyvVfVKmbhMD1VtRbh5enGHxkaQDqWyLefiKOGGmohGDDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "node_modules/fdir": {
@@ -3016,6 +3143,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
@@ -3523,6 +3656,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3544,6 +3683,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.40.4",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.40.4.tgz",
+      "integrity": "sha512-ZAv+KNavneRVzu4tUeOgzkScI3W5BGwZ3rkxIpKtzzVgfTtWQFN1CgX0U72cyvyh3iTuHL3SiSmrQxTlryEIcw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.4"
       }
     },
     "node_modules/ms": {
@@ -3603,6 +3751,12 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
       "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
@@ -4200,6 +4354,26 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-regex2": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
@@ -4230,6 +4404,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -4334,6 +4514,19 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/steed": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/steed/-/steed-1.1.3.tgz",
+      "integrity": "sha512-EUkci0FAUiE4IvGTSKcDJIQ/eRUP2JJb56+fvZ4sdnguLTqIdKjSxUe138poW8mkvKWXW2sFPrgTsxqoISnmoA==",
+      "license": "MIT",
+      "dependencies": {
+        "fastfall": "^1.5.0",
+        "fastparallel": "^2.2.0",
+        "fastq": "^1.3.0",
+        "fastseries": "^1.7.0",
+        "reusify": "^1.0.0"
       }
     },
     "node_modules/string-width": {
@@ -4785,7 +4978,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.2.0",
+        "@fastify/jwt": "^10.1.0",
         "bcrypt": "^6.0.0",
         "dotenv": "^17.3.1",
         "fastify": "^5.8.2",

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,2 +1,21 @@
 NODE_ENV=production || development #environment
-PORT=0000 #port
+
+# Server
+PORT=8080
+
+# Database Defaults
+DB_HOST=localhost
+DB_PORT=6543
+DB_PORT_INTERNAL=5432
+DB_NAME=quiz_db
+DB_USER=postgres
+DB_PASSWORD=your_postgres_password_here
+
+# pgAdmin Dashboard
+PGADMIN_DEFAULT_EMAIL=admin@example.com
+PGADMIN_DEFAULT_PASSWORD=your_pgadmin_password_here
+PGADMIN_PORT=5050
+
+# Security
+# Generate a secure string using: node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+JWT_SECRET=your_jwt_secret_here

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.2.0",
+    "@fastify/jwt": "^10.1.0",
     "bcrypt": "^6.0.0",
     "dotenv": "^17.3.1",
     "fastify": "^5.8.2",

--- a/server/server.js
+++ b/server/server.js
@@ -35,7 +35,7 @@ fastify.register(cors, {
 
 fastify.register(fastifyCookie);
 
-fastify.register(fastifyJwt, {
+fastify.register(fastifyJWT, {
     secret: process.env.JWT_SECRET,
     cookie: {
         cookieName: "token",

--- a/server/server.js
+++ b/server/server.js
@@ -30,13 +30,14 @@ const fastify = Fastify({
 //CORS usage libriary
 fastify.register(cors, {
     origin: "http://localhost:3000",
+    credentials: true,
     methods: ["GET", "PUT", "POST", "DELETE"],
 });
 
 fastify.register(fastifyCookie);
 
 fastify.register(fastifyJWT, {
-    secret: process.env.JWT_SECRET,
+    secret: env.JWT_SECRET,
     cookie: {
         cookieName: "token",
         signed: false,

--- a/server/server.js
+++ b/server/server.js
@@ -1,33 +1,46 @@
 import Fastify from "fastify";
-import cors from "@fastify/cors"
+import cors from "@fastify/cors";
+import fastifyCookie from "@fastify/cookie";
+import fastifyJWT from "@fastify/jwt";
 
-import { env } from './src/config/env.js'
-import homeRoutes from './src/apps/home/entry-points/home.routes.js'
+import { env } from "./src/config/env.js";
+import homeRoutes from "./src/apps/home/entry-points/home.routes.js";
 import authRoutes from "./src/apps/auth/entry-points/auth.routes.js";
-import eventHandler from './src/libraries/events/events.controller.js'
+import eventHandler from "./src/libraries/events/events.controller.js";
 
-import query from './src/db/pool.js';
+import query from "./src/db/pool.js";
 
 const PORT = env.PORT;
 
 // logging libriary
 const ENV = env.NODE_ENV;
 const fastify = Fastify({
-    logger: ENV ? true :
-    {
-        transport: {
-            target: "pino-pretty",
-            options: {
-                translateTime: "HH:MM:ss Z",
-            },
-        },
-    },
+    logger: ENV
+        ? true
+        : {
+              transport: {
+                  target: "pino-pretty",
+                  options: {
+                      translateTime: "HH:MM:ss Z",
+                  },
+              },
+          },
 });
 
 //CORS usage libriary
 fastify.register(cors, {
-    origin: 'http://localhost:3000',
-    methods: ['GET', 'PUT', 'POST', 'DELETE'], 
+    origin: "http://localhost:3000",
+    methods: ["GET", "PUT", "POST", "DELETE"],
+});
+
+fastify.register(fastifyCookie);
+
+fastify.register(fastifyJwt, {
+    secret: process.env.JWT_SECRET,
+    cookie: {
+        cookieName: "token",
+        signed: false,
+    },
 });
 
 //listening for server
@@ -41,24 +54,23 @@ const getSchema = {
     response: {
         200: {
             properties: {
-                message: { type: 'string' }
-            } 
-        }
-    }
+                message: { type: "string" },
+            },
+        },
+    },
 };
 
-//streams practice 
-fastify.register(eventHandler, {prefix: '/stream'});
+//streams practice
+fastify.register(eventHandler, { prefix: "/stream" });
 
 // home
-fastify.register(homeRoutes, {prefix: '/home'});
+fastify.register(homeRoutes, { prefix: "/home" });
 
-// auth 
-fastify.register(authRoutes, {prefix: '/auth'});
+// auth
+fastify.register(authRoutes, { prefix: "/auth" });
 
 try {
     await fastify.listen(port);
-    
 } catch (err) {
     fastify.log.fatal(err);
     process.exit(1);
@@ -69,5 +81,3 @@ try {
 //         process.exit(1);
 //     }
 // });
-
-

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -65,10 +65,13 @@ export const logIn = async (req, reply) => {
     try {
         const { id, message } = await authService.logIn(validData);
 
-        const token = await reply.jwtSign({
-            userId: id,
-            role: "user",
-        });
+        const token = await reply.jwtSign(
+            {
+                userId: id,
+                role: "user",
+            },
+            { expiresIn: "7d" },
+        );
 
         reply.setCookie("token", token, {
             domain: "localhost",
@@ -76,6 +79,7 @@ export const logIn = async (req, reply) => {
             // secure: true, // HTTPS only
             httpOnly: true,
             sameSite: "strict",
+            maxAge: 7 * 24 * 60 * 60,
         });
 
         return reply.status(200).send({ message: "Login successful" });
@@ -93,19 +97,16 @@ export const logIn = async (req, reply) => {
 
 export const getUser = async (req, reply) => {
     try {
-        await req.jwtVerify(); 
-    
-        return reply.status(200).send({ user: req.user });
+        await req.jwtVerify();
 
+        return reply.status(200).send({ user: req.user });
     } catch (error) {
-        
         return reply.status(401).send({ error: "Unauthorized" });
     }
 };
 
 export const logOut = async (req, reply) => {
     reply.clearCookie("token", { path: "/" });
-    
+
     return reply.status(200).send({ message: "Logged out successfully" });
 };
-

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -65,7 +65,20 @@ export const logIn = async (req, reply) => {
     try {
         const { id, message } = await authService.logIn(validData);
 
-        return reply.status(200).send({ id, message });
+        const token = await reply.jwtSign({
+            userId: id,
+            role: "user",
+        });
+
+        reply.setCookie("token", token, {
+            domain: "localhost",
+            path: "/",
+            // secure: true, // HTTPS only
+            httpOnly: true,
+            sameSite: "strict",
+        });
+
+        return reply.status(200).send({ message: "Login successful" });
     } catch (error) {
         if (error.statusCode === 401) {
             return reply
@@ -77,3 +90,4 @@ export const logIn = async (req, reply) => {
         return reply.status(500).send({ error: "Internal Server Error" });
     }
 };
+

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -91,3 +91,14 @@ export const logIn = async (req, reply) => {
     }
 };
 
+export const getUser = async (req, reply) => {
+    try {
+        await req.jwtVerify(); 
+    
+        return reply.status(200).send({ user: req.user });
+
+    } catch (error) {
+        
+        return reply.status(401).send({ error: "Unauthorized" });
+    }
+};

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -102,3 +102,10 @@ export const getUser = async (req, reply) => {
         return reply.status(401).send({ error: "Unauthorized" });
     }
 };
+
+export const logOut = async (req, reply) => {
+    reply.clearCookie("token", { path: "/" });
+    
+    return reply.status(200).send({ message: "Logged out successfully" });
+};
+

--- a/server/src/apps/auth/entry-points/auth.routes.js
+++ b/server/src/apps/auth/entry-points/auth.routes.js
@@ -9,5 +9,7 @@ export default function authRoutes (fastify, components, done) {
 
     fastify.get("/user", authController.getUser);
 
+    fastify.post("/logout", authController.logOut);
+
     done();
 }

--- a/server/src/apps/auth/entry-points/auth.routes.js
+++ b/server/src/apps/auth/entry-points/auth.routes.js
@@ -7,5 +7,7 @@ export default function authRoutes (fastify, components, done) {
     
     fastify.post("/login", authController.logIn);
 
+    fastify.get("/user", authController.getUser);
+
     done();
 }


### PR DESCRIPTION
### WHAT CHANGED

JWTs are now issued as HTTP-Only cookies on login. `SameSite=Strict` prevents CSRF. The token payload is minimal — `userId` and `role` only. A `/auth/me` route lets the frontend know who is logged in without parsing the token client-side.

### HOW TO TEST

- [ ] Login — inspect response headers for `Set-Cookie`
- [ ] `GET /auth/me` with cookie — verify user returned
- [ ] `GET /auth/me` without cookie — 401
- [ ] `POST /auth/logout` — verify cookie cleared

### FILES CHANGED

```diff
+src/plugins/jwt.js
+src/plugins/cookie.js
~src/modules/auth/auth.controller.js (cookie logic)
~.env.example (JWT_SECRET added)