### PR TITLE
feat: add JWT auth preHandler hook to protect API routes

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,7 @@ import authRoutes from "./src/apps/auth/entry-points/auth.routes.js";
 import eventHandler from "./src/libraries/events/events.controller.js";
 import { loggerConfig } from "./src/config/logger/logger.config.js";
 import query from "./src/db/pool.js";
+import protectedRoutes from "./src/hooks/authenticate.js";
 
 const PORT = env.PORT;
 
@@ -53,6 +54,8 @@ fastify.register(eventHandler, { prefix: "/stream" });
 
 // home
 fastify.register(homeRoutes, { prefix: "/home" });
+fastify.register(protectedRoutes, { prefix: "/api" });
+
 
 // auth
 fastify.register(authRoutes, { prefix: "/auth" });

--- a/server/src/apps/auth/entry-points/auth.controller.js
+++ b/server/src/apps/auth/entry-points/auth.controller.js
@@ -131,7 +131,7 @@ export const refresh = async (req, reply) => {
             const accessToken = await reply.jwtSign(
                 {
                     userId: decodedToken.userId,
-                    role: "student",
+                    role: "student",//will be changed
                 },
                 { expiresIn: "15m" },
             );

--- a/server/src/apps/auth/entry-points/auth.routes.js
+++ b/server/src/apps/auth/entry-points/auth.routes.js
@@ -1,9 +1,9 @@
 import * as authController from "./auth.controller.js";
 
 export default function authRoutes (fastify, components, done) {
-    fastify.post("/register", authController.register);
+    fastify.post("/register", authController.register); //registration
 
-    fastify.get("/verify", authController.verify);
+    fastify.get("/verify", authController.verify); //email verification during registration
     
     fastify.post("/login", authController.logIn);
 

--- a/server/src/hooks/authenticate.js
+++ b/server/src/hooks/authenticate.js
@@ -1,5 +1,5 @@
-import { authenticate } from "../apps/auth/middlewares/authenticate";
-import homeRoutes from "../apps/home/entry-points/home.routes";
+import { authenticate } from "../apps/auth/middlewares/authenticate.js";
+import homeRoutes from "../apps/home/entry-points/home.routes.js";
 
 export default async function protectedRoutes (childserver) {
     childserver.addHook('preHandler', authenticate);

--- a/server/src/hooks/authenticate.js
+++ b/server/src/hooks/authenticate.js
@@ -1,0 +1,10 @@
+import { authenticate } from "../apps/auth/middlewares/authenticate";
+import homeRoutes from "../apps/home/entry-points/home.routes";
+
+export default async function protectedRoutes (childserver) {
+    childserver.addHook('preHandler', authenticate);
+
+    childserver.register(homeRoutes, { prefix: '/home'});
+    //...
+}
+


### PR DESCRIPTION
A Fastify `preHandler` hook intercepts every `/api` request and verifies the JWT cookie. On failure it short-circuits with 401 before the controller ever runs. `request.user` is attached for controllers to read. Public auth routes are explicitly excluded.

**HOW TO TEST**

- [ ] GET `/api/quizzes` without cookie — 401
- [ ] GET `/api/quizzes` with valid cookie — 200
- [ ] GET `/api/quizzes` with expired JWT — 401 (not 500)

**FILES CHANGED**

```diff
+ src/hooks/authenticate.js
! src/app.js (hook applied to /api prefix)
```